### PR TITLE
Add calendar modal and button to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,22 @@
             </div>
         </h1>
         <div class="subtitle">HKU - SPANISH DEPARTMENT</div>
+        <button class="calendar-button" id="calendar-btn">📅 Calendar</button>
+    </div>
+
+    <!-- Modal del calendario -->
+    <div class="calendar-modal" id="calendar-modal">
+        <div class="calendar-content">
+            <div class="calendar-header">
+                <button class="calendar-nav" id="prev-month">‹</button>
+                <h3 id="calendar-month-year">August 2025</h3>
+                <button class="calendar-nav" id="next-month">›</button>
+                <button class="calendar-close" id="calendar-close">✕</button>
+            </div>
+            <div class="calendar-grid" id="calendar-grid">
+                <!-- El calendario se genera dinámicamente -->
+            </div>
+        </div>
     </div>
 
     <div class="game-container">


### PR DESCRIPTION
## Summary
- add Calendar button next to subtitle on index page
- include calendar modal structure for dynamic calendar

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/SPAN1001Palabrero/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a03aec2980832796ef2b18bbf23b05