### PR TITLE
Initialize game with stored words and calendar

### DIFF
--- a/script.js
+++ b/script.js
@@ -378,13 +378,16 @@ class WordleHKU {
     }
 }
 
+let currentGame;
+let wordsData;
+
 async function initializeGame() {
     try {
         const response = await fetch('palabras.json');
         if (!response.ok) {
             throw new Error('Could not load words file (palabras.json).');
         }
-        const data = await response.json();
+        wordsData = await response.json();
 
         // Obtener la fecha de hoy en formato AAAA-MM-DD
         const today = new Date();
@@ -394,11 +397,12 @@ async function initializeGame() {
         const todayString = `${year}-${month}-${day}`;
 
         // Buscar la palabra correspondiente a la fecha de hoy
-        const wordData = data.words.find(w => w.date === todayString);
+        const wordData = wordsData.words.find(w => w.date === todayString);
 
         if (wordData && wordData.word) {
             // Si se encuentra la palabra para hoy, se crea una nueva instancia del juego
-            new WordleHKU(wordData.word, wordData.hint);
+            currentGame = new WordleHKU(wordData.word, wordData.hint);
+            new Calendar();
         } else {
             // Mensaje si no hay palabra asignada para el día
             document.querySelector('.game-container').innerHTML = '<h1>No word scheduled for today.</h1>';


### PR DESCRIPTION
## Summary
- Store fetched `palabras.json` data in a global `wordsData` variable.
- Instantiate and store the daily `WordleHKU` game in `currentGame`.
- Initialize the calendar after game setup.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a03af13b408327804319206e3c5353