### PR TITLE
Track completed puzzles and add calendar selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,10 @@
             <div class="hint-display" id="hint-display"></div>
         </div>
 
+        <div class="calendar-section">
+            <button class="calendar-button" id="calendar-btn">📅 Calendario</button>
+        </div>
+
         <div class="game-board" id="game-board"></div>
         <div class="keyboard" id="keyboard"></div>
 
@@ -65,6 +69,10 @@
     </div>
 
     <div class="message" id="message"></div>
+
+    <div class="calendar-overlay" id="calendar-overlay" style="display:none;">
+        <div class="calendar-container" id="calendar-container"></div>
+    </div>
 
     <div class="footer">
         <p>SPAN1001 Palabrarero • HKU Spanish Department</p>

--- a/style.css
+++ b/style.css
@@ -434,3 +434,90 @@ body {
     background: linear-gradient(135deg, #0075A8, #00A651);
     border-color: #FFED4E;
 }
+
+/* Calendar styles */
+.calendar-section {
+    margin-bottom: 20px;
+}
+
+.calendar-button {
+    padding: 10px 20px;
+    background: #FFED4E;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.calendar-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.calendar-container .calendar {
+    background: white;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+}
+
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 40px);
+    gap: 5px;
+    margin-top: 10px;
+}
+
+.calendar-day {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.calendar-day.available {
+    background: linear-gradient(135deg, #00A651, #0075A8);
+    color: white;
+}
+
+.calendar-day.completed {
+    background: linear-gradient(135deg, #FFED4E, #DC6900);
+    color: white;
+}
+
+.calendar-day.unavailable {
+    background: #ccc;
+    color: #777;
+    cursor: default;
+}
+
+.calendar-day.future {
+    background: #eee;
+    color: #aaa;
+    cursor: default;
+}
+
+.calendar-day.today {
+    border: 2px solid #3B1F00;
+}
+
+.calendar-close-btn {
+    margin-top: 10px;
+    padding: 5px 10px;
+    border: none;
+    background: #DC6900;
+    color: white;
+    border-radius: 5px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Track daily completion and prevent duplicate scoring
- Adjust scoring, hints, and timer for archive and repeat plays
- Add calendar interface with day status indicators

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a03c4fa15c8327a0db8c137a299bb5